### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ponyd/downloader.py
+++ b/ponyd/downloader.py
@@ -18,7 +18,7 @@ class Downloader(PonydCommand):
     __subcommand__  = 'update-devtools'
 
     dirname = Arg(nargs='?',
-                  help='path to download and extract devtools (default: %s)' % DEFAULT_DEVTOOLS_PATH,
+                  help='path to download and extract devtools (default: {0!s})'.format(DEFAULT_DEVTOOLS_PATH),
                   default=DEFAULT_DEVTOOLS_PATH)
     latest = Arg('-l', '--latest',
                  help='install the lastest dev tools instead of a known good version',
@@ -31,17 +31,17 @@ class Downloader(PonydCommand):
             version = 152100
 
         tools_url = TOOLS_URL_TEMPLATE % version 
-        print "Downloading %s" % tools_url
+        print "Downloading {0!s}".format(tools_url)
 
         tools_stream = StringIO(urllib2.urlopen(tools_url).read())
 
 
         if os.path.exists(self.dirname):
-            print "Removing existing devtools installation at %s" % self.dirname
+            print "Removing existing devtools installation at {0!s}".format(self.dirname)
             shutil.rmtree(self.dirname)
 
         extract_dir = self.dirname
-        print "Extracting to %s" % extract_dir
+        print "Extracting to {0!s}".format(extract_dir)
 
         tools_zip = zipfile.ZipFile(tools_stream, 'r')
         tools_zip.extractall(path=extract_dir)

--- a/ponyd/gateway.py
+++ b/ponyd/gateway.py
@@ -145,7 +145,7 @@ class DeviceHandler(tornado.websocket.WebSocketHandler):
         self.app_state.registerDevice(self)
 
         # Announce existence.
-        logger.info("Device %s Registered (%s, %s)" % (self.deviceID,
+        logger.info("Device {0!s} Registered ({1!s}, {2!s})".format(self.deviceID,
                                                        self.device_model,
                                                        self.device_name))
 
@@ -240,7 +240,7 @@ class Gateway(PonydCommand):
 
     def __call__(self):
         if not os.path.exists(self.devtools_path):
-            print "Error: devtools directory %s does not exist. Use 'ponyd update-devtools' to download a compatible version of Chrome Developer Tools." % self.devtools_path
+            print "Error: devtools directory {0!s} does not exist. Use 'ponyd update-devtools' to download a compatible version of Chrome Developer Tools.".format(self.devtools_path)
             return
 
         if self.verbose:
@@ -257,7 +257,7 @@ class Gateway(PonydCommand):
             (r"/(.*)", tornado.web.StaticFileHandler, {"path": self.static_path, "default_filename": 'index.html'}),
         ])
 
-        print "PonyGateway starting. Listening on http://%s:%s" % (self.listen_interface, self.listen_port)
+        print "PonyGateway starting. Listening on http://{0!s}:{1!s}".format(self.listen_interface, self.listen_port)
 
         bonjour.register_service(self.bonjour_name, "_ponyd._tcp", self.listen_port)
 

--- a/scripts/_bootstrap_contents.py
+++ b/scripts/_bootstrap_contents.py
@@ -19,13 +19,13 @@ def after_install(options, home_dir):
             symlink_target  = os.path.join(symlink_target, 'ponyd')
 
         if os.path.exists(symlink_target):
-            print "Symlink to %s already exists. (continuing anyways)" % symlink_target
+            print "Symlink to {0!s} already exists. (continuing anyways)".format(symlink_target)
         try:
-            print "Symlinking %s to %s" % (ponyd_path, symlink_target)
+            print "Symlinking {0!s} to {1!s}".format(ponyd_path, symlink_target)
             os.symlink(ponyd_path, symlink_target)
         except:
-            print >>sys.stderr, "Error creating symlink. Manually run: sudo ln -s '%s' '%s'" % (ponyd_path, symlink_target)
+            print >>sys.stderr, "Error creating symlink. Manually run: sudo ln -s '{0!s}' '{1!s}'".format(ponyd_path, symlink_target)
 
     subprocess.check_call([ponyd_path, 'update-devtools'])
 
-    print "Congratulations! ponyd has been installed to %s" % ponyd_path
+    print "Congratulations! ponyd has been installed to {0!s}".format(ponyd_path)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:PonyDebugger?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:PonyDebugger?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
